### PR TITLE
check token is valid if expired; add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ jwt({ secret: 'shhhhhhared-secret',
 
 > If the JWT has an expiration (`exp`), it will be checked.
 
+You can supply an `isExpired` callback to handle the case when a token is expired, but otherwise completely valid:
+
+```javascript
+function expiredCallback(err, req, next) {
+  // handle an expired token, instead of raising an error
+  let shouldContinueAnyways = false
+  // TODO: determine if we should accept the token anyways
+  if (shouldContinueAnyways) {
+    next()  // silence the TokenExpiredError and continue with req.user set
+  } else {
+    next(err)  // should raise the original TokenExpiredError
+  }
+}
+jwt({secret: 'shhhhhhared-secret', isExpired: expiredCallback}),
+```
+
 If you are using a base64 URL-encoded secret, pass a `Buffer` with `base64` encoding as the secret instead of a string:
 
 ```javascript

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,15 +101,23 @@ module.exports = function(options) {
         jwt.verify(token, secret, options, function(err, decoded) {
           if (err) {
             if (err.message === 'jwt expired' && isFunction(isExpiredCallback)) {
-                set(req, _requestProperty, dtoken.payload);
-                isExpiredCallback(err, req, function (err) {
-                    if (err) {
+                // verify the token, but ignore the exp claim to ensure token is completely valid otherwise
+                let optionsPlusIgnoreExpiration = Object.assign({ignoreExpiration: true}, options)
+                jwt.verify(token, secret, optionsPlusIgnoreExpiration, function(err, decoded) {
+                  if (err) {
+                    callback(new UnauthorizedError('invalid_token', err));
+                  } else {
+                    set(req, _requestProperty, dtoken.payload);
+                    isExpiredCallback(err, req, function (err) {
+                      if (err) {
                         callback(new UnauthorizedError('invalid_token', err));
-                    } else {
+                      } else {
                         _decoded = jwt.decode(token);
                         callback(null, _decoded)
-                    }
-                });
+                      }
+                    });
+                  }
+                })
             } else {
                 callback(new UnauthorizedError('invalid_token', err));
             }


### PR DESCRIPTION
I love this implementation, and wanted to write some tests & docs to help get it accepted into auth0/express-jwt . However, while writing the tests, I found that incorrect issuer errors get swallowed with the current implementation, if `next()` is called in the `isExpired` callback on a token that is both expired and to an incorrect issuer.